### PR TITLE
Make CLI fail gracefully and add regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
-# ai-news-publisher
+# AI News Publisher
+
+`ai-news-publisher` provides a small, runnable pipeline to normalize AI news items and generate a publish-ready markdown digest.
+
+## What is implemented
+
+- Input validation for required text fields, URL format, and timestamp format.
+- Timestamp normalization to UTC (naive timestamps are treated as UTC).
+- Story normalization into a typed model.
+- URL de-duplication (most recently published duplicate wins).
+- Reverse-chronological sorting.
+- Markdown digest generation grouped by category.
+- CLI command to transform JSON input into a digest file with clear validation errors.
+
+## Quick Start
+
+### 1) Create and activate a virtual environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+### 2) Install the package in editable mode
+
+```bash
+pip install -e .
+```
+
+### 3) Create an input file
+
+Example `sample_news.json`:
+
+```json
+[
+  {
+    "title": "New model release",
+    "source": "Example AI Blog",
+    "url": "https://example.com/model-release",
+    "summary": "A new family of models was announced.",
+    "published_at": "2026-01-20T10:30:00+00:00",
+    "category": "product"
+  },
+  {
+    "title": "Benchmark update",
+    "source": "Research Weekly",
+    "url": "https://example.com/benchmark-update",
+    "summary": "Researchers published a new evaluation result.",
+    "published_at": "2026-01-19T14:00:00+00:00",
+    "category": "research"
+  }
+]
+```
+
+### 4) Generate a digest
+
+```bash
+ai-news-publisher sample_news.json --output digest.md
+```
+
+The command prints a summary and writes the formatted digest to `digest.md`.
+
+## Development
+
+Run tests:
+
+```bash
+pytest
+```
+
+## License
+
+This project is licensed under the terms in [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ai-news-publisher"
+version = "0.1.0"
+description = "Minimal pipeline to normalize AI news items and generate a markdown digest"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "ai-news-publisher contributors" }]
+dependencies = []
+
+[project.scripts]
+ai-news-publisher = "ai_news_publisher.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-q"

--- a/src/ai_news_publisher/__init__.py
+++ b/src/ai_news_publisher/__init__.py
@@ -1,0 +1,6 @@
+"""AI News Publisher package."""
+
+from .models import NewsItem
+from .pipeline import generate_markdown_digest, normalize_items
+
+__all__ = ["NewsItem", "normalize_items", "generate_markdown_digest"]

--- a/src/ai_news_publisher/cli.py
+++ b/src/ai_news_publisher/cli.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .pipeline import generate_markdown_digest, normalize_items
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate an AI news markdown digest from JSON input.")
+    parser.add_argument("input", type=Path, help="Path to JSON file containing a list of news item objects")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("digest.md"),
+        help="Output markdown file path (default: digest.md)",
+    )
+    return parser
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        raw_text = args.input.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading input file '{args.input}': {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        raw = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        print(f"Error parsing JSON in '{args.input}': {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(raw, list):
+        print("Input JSON must be a list of item objects", file=sys.stderr)
+        return 1
+
+    try:
+        items = normalize_items(raw)
+    except ValueError as exc:
+        print(f"Invalid news item data: {exc}", file=sys.stderr)
+        return 1
+
+    digest = generate_markdown_digest(items)
+    try:
+        args.output.write_text(digest, encoding="utf-8")
+    except OSError as exc:
+        print(f"Error writing output file '{args.output}': {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Wrote {len(items)} normalized stories to {args.output}")
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_news_publisher/models.py
+++ b/src/ai_news_publisher/models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class NewsItem:
+    title: str
+    source: str
+    url: str
+    summary: str
+    published_at: datetime
+    category: str = "general"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "NewsItem":
+        if not isinstance(data, dict):
+            raise ValueError("Each item must be an object/dictionary")
+
+        title = _clean_required_text(data, "title")
+        source = _clean_required_text(data, "source")
+        url = _clean_required_text(data, "url")
+        summary = _clean_required_text(data, "summary")
+        _validate_http_url(url)
+
+        published_at = _parse_published_at(data.get("published_at"))
+
+        return cls(
+            title=title,
+            source=source,
+            url=url,
+            summary=summary,
+            published_at=published_at,
+            category=str(data.get("category", "general")).strip().lower() or "general",
+        )
+
+
+def _clean_required_text(data: dict[str, Any], field: str) -> str:
+    value = data.get(field)
+    if value is None:
+        raise ValueError(f"Missing required field: {field}")
+
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"Field '{field}' must be a non-empty string")
+
+    return text
+
+
+def _validate_http_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Field 'url' must be a valid absolute HTTP(S) URL")
+
+
+def _parse_published_at(raw_published_at: Any) -> datetime:
+    if raw_published_at is None:
+        raise ValueError("Missing required field: published_at")
+
+    published_text = str(raw_published_at).strip()
+    if not published_text:
+        raise ValueError("Field 'published_at' must be a non-empty string")
+
+    try:
+        published_at = datetime.fromisoformat(published_text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("Field 'published_at' must be a valid ISO-8601 datetime") from exc
+
+    # Normalize timestamps to timezone-aware UTC so sorting/comparison is stable.
+    if published_at.tzinfo is None:
+        return published_at.replace(tzinfo=timezone.utc)
+
+    return published_at.astimezone(timezone.utc)

--- a/src/ai_news_publisher/pipeline.py
+++ b/src/ai_news_publisher/pipeline.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+
+from .models import NewsItem
+
+
+def normalize_items(raw_items: list[dict]) -> list[NewsItem]:
+    """Convert raw dictionaries into validated NewsItem objects.
+
+    Duplicate URLs are collapsed by keeping the most recently published story,
+    and items are sorted by publication time descending.
+    """
+
+    latest_by_url: dict[str, NewsItem] = {}
+
+    for raw in raw_items:
+        item = NewsItem.from_dict(raw)
+        existing = latest_by_url.get(item.url)
+        if existing is None or item.published_at > existing.published_at:
+            latest_by_url[item.url] = item
+
+    normalized = list(latest_by_url.values())
+    normalized.sort(key=lambda item: item.published_at, reverse=True)
+    return normalized
+
+
+def generate_markdown_digest(items: list[NewsItem], digest_date: date | None = None) -> str:
+    """Render normalized items into a grouped markdown digest."""
+
+    digest_date = digest_date or date.today()
+    grouped: dict[str, list[NewsItem]] = defaultdict(list)
+    for item in items:
+        grouped[item.category].append(item)
+
+    lines = [f"# AI News Digest - {digest_date.isoformat()}", ""]
+    for category in sorted(grouped):
+        lines.append(f"## {category.title()}")
+        lines.append("")
+        for item in grouped[category]:
+            stamp = item.published_at.strftime("%Y-%m-%d %H:%M")
+            lines.append(f"- [{item.title}]({item.url}) — **{item.source}** ({stamp})")
+            lines.append(f"  - {item.summary}")
+        lines.append("")
+
+    if len(lines) == 2:
+        lines.extend(["_No stories available._", ""])
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from ai_news_publisher.cli import run
+
+
+def test_cli_run_success_writes_digest(tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "news.json"
+    output_path = tmp_path / "digest.md"
+    input_path.write_text(
+        """
+        [
+          {
+            "title": "Launch",
+            "source": "Blog",
+            "url": "https://example.com/launch",
+            "summary": "Shipped",
+            "published_at": "2026-01-02T10:00:00+00:00"
+          }
+        ]
+        """,
+        encoding="utf-8",
+    )
+
+    code = run([str(input_path), "--output", str(output_path)])
+
+    assert code == 0
+    assert output_path.exists()
+    assert "Wrote 1 normalized stories" in capsys.readouterr().out
+
+
+def test_cli_run_handles_missing_input_file(tmp_path: Path, capsys) -> None:
+    missing_path = tmp_path / "missing.json"
+
+    code = run([str(missing_path)])
+
+    assert code == 1
+    assert "Error reading input file" in capsys.readouterr().err
+
+
+def test_cli_run_handles_invalid_json(tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "bad.json"
+    input_path.write_text("{bad json", encoding="utf-8")
+
+    code = run([str(input_path)])
+
+    assert code == 1
+    assert "Error parsing JSON" in capsys.readouterr().err
+
+
+def test_cli_run_handles_invalid_item_data(tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "bad-item.json"
+    input_path.write_text(
+        """
+        [
+          {
+            "title": "   ",
+            "source": "Blog",
+            "url": "https://example.com/launch",
+            "summary": "Shipped",
+            "published_at": "2026-01-02T10:00:00+00:00"
+          }
+        ]
+        """,
+        encoding="utf-8",
+    )
+
+    code = run([str(input_path)])
+
+    assert code == 1
+    assert "Invalid news item data" in capsys.readouterr().err

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,148 @@
+from datetime import date
+
+import pytest
+
+from ai_news_publisher.pipeline import generate_markdown_digest, normalize_items
+
+
+def test_normalize_items_deduplicates_by_keeping_newest_and_sorts_descending() -> None:
+    raw = [
+        {
+            "title": "Older story",
+            "source": "Source A",
+            "url": "https://example.com/1",
+            "summary": "Summary 1",
+            "published_at": "2026-01-01T09:00:00+00:00",
+            "category": "research",
+        },
+        {
+            "title": "Newest story",
+            "source": "Source B",
+            "url": "https://example.com/2",
+            "summary": "Summary 2",
+            "published_at": "2026-01-02T09:00:00+00:00",
+            "category": "product",
+        },
+        {
+            "title": "Updated duplicate should be kept",
+            "source": "Source C",
+            "url": "https://example.com/2",
+            "summary": "Summary duplicate",
+            "published_at": "2026-01-03T09:00:00+00:00",
+            "category": "product",
+        },
+    ]
+
+    items = normalize_items(raw)
+
+    assert [item.url for item in items] == ["https://example.com/2", "https://example.com/1"]
+    assert [item.title for item in items] == ["Updated duplicate should be kept", "Older story"]
+
+
+def test_normalize_items_requires_fields() -> None:
+    with pytest.raises(ValueError, match="Missing required field: title"):
+        normalize_items([
+            {
+                "source": "Nowhere",
+                "url": "https://example.com/missing-title",
+                "summary": "Summary",
+                "published_at": "2026-01-01T00:00:00Z",
+            }
+        ])
+
+
+def test_normalize_items_rejects_whitespace_only_required_text() -> None:
+    with pytest.raises(ValueError, match="Field 'title' must be a non-empty string"):
+        normalize_items([
+            {
+                "title": "   ",
+                "source": "Nowhere",
+                "url": "https://example.com/blank-title",
+                "summary": "Summary",
+                "published_at": "2026-01-01T00:00:00Z",
+            }
+        ])
+
+
+def test_normalize_items_rejects_invalid_url() -> None:
+    with pytest.raises(ValueError, match=r"valid absolute HTTP\(S\) URL"):
+        normalize_items([
+            {
+                "title": "Bad url",
+                "source": "Nowhere",
+                "url": "example.com/no-scheme",
+                "summary": "Summary",
+                "published_at": "2026-01-01T00:00:00Z",
+            }
+        ])
+
+
+def test_normalize_items_rejects_invalid_datetime() -> None:
+    with pytest.raises(ValueError, match="published_at"):
+        normalize_items([
+            {
+                "title": "Bad date",
+                "source": "Nowhere",
+                "url": "https://example.com/bad-date",
+                "summary": "Oops",
+                "published_at": "not-a-date",
+            }
+        ])
+
+
+def test_normalize_items_accepts_mixed_naive_and_aware_datetimes() -> None:
+    items = normalize_items(
+        [
+            {
+                "title": "Naive",
+                "source": "Source A",
+                "url": "https://example.com/naive",
+                "summary": "No timezone provided",
+                "published_at": "2026-01-01T10:00:00",
+            },
+            {
+                "title": "Aware",
+                "source": "Source B",
+                "url": "https://example.com/aware",
+                "summary": "UTC timestamp",
+                "published_at": "2026-01-01T09:30:00+00:00",
+            },
+        ]
+    )
+
+    assert [item.title for item in items] == ["Naive", "Aware"]
+
+
+def test_normalize_items_rejects_non_object_entries() -> None:
+    with pytest.raises(ValueError, match="object/dictionary"):
+        normalize_items(["not-an-object"])
+
+
+def test_generate_markdown_digest_groups_by_category() -> None:
+    items = normalize_items(
+        [
+            {
+                "title": "Research update",
+                "source": "Lab",
+                "url": "https://example.com/research",
+                "summary": "New benchmark",
+                "published_at": "2026-01-01T09:00:00+00:00",
+                "category": "research",
+            },
+            {
+                "title": "Product launch",
+                "source": "Vendor",
+                "url": "https://example.com/product",
+                "summary": "New assistant feature",
+                "published_at": "2026-01-02T10:00:00+00:00",
+                "category": "product",
+            },
+        ]
+    )
+
+    digest = generate_markdown_digest(items, digest_date=date(2026, 1, 5))
+
+    assert "# AI News Digest - 2026-01-05" in digest
+    assert "## Product" in digest
+    assert "## Research" in digest
+    assert "[Product launch](https://example.com/product)" in digest


### PR DESCRIPTION
### Motivation

- The CLI previously surfaced raw Python tracebacks for common user errors which made the tool unfriendly and hard to script.  
- A testable, script-friendly CLI entrypoint that returns an exit code is needed to allow automated workflows and unit tests.  
- Clear, one-line error messages improve usability when input files are missing or malformed.

### Description

- Reworked the CLI to add a `run(argv)` function that returns `0`/`1` and made `main()` a thin wrapper (`SystemExit(run())`) to keep the module runnable.  
- Replaced uncaught exceptions with targeted `try/except` handling to print friendly errors for input read failures, JSON parse errors, non-list top-level JSON, invalid item data, and output write errors.  
- Added CLI-focused regression tests in `tests/test_cli.py` covering the success path and key error cases (`missing file`, `invalid JSON`, and `invalid item data`).  
- Updated `README.md` to document the improved CLI behavior and validation messages.

### Testing

- Ran `pytest` with the test suite which completed successfully (`12 passed`).  
- Executed a smoke test `PYTHONPATH=src python -m ai_news_publisher.cli missing.json` which exited with code `1` and printed a concise error message as expected.  
- Verified the CLI behavior via the new unit tests which assert return codes and stderr/stdout for the covered scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bfe8e2ad4832ba99b51dfc6054b0a)